### PR TITLE
refactor(headercell): pass header as children instead of prop

### DIFF
--- a/src/column/Column.tsx
+++ b/src/column/Column.tsx
@@ -13,10 +13,10 @@ interface ColumnOwnProps<D, C> {
 export type ColumnProps<D, C> = PropsWithChildren<ColumnOwnProps<D, C>>;
 
 export function Column<D, C>(props: ColumnProps<D, C>) {
-  const { children = <DefaultContent />, accessor = null } = props;
+  const { children = <DefaultContent />, accessor = null, header } = props;
   const part = useTablePart();
   if (part === 'header') {
-    return <HeaderCell header={props.header} />;
+    return <HeaderCell>{header}</HeaderCell>;
   }
   if (part === 'body') {
     return <Cell accessor={accessor}>{children}</Cell>;

--- a/src/header/HeaderCell.tsx
+++ b/src/header/HeaderCell.tsx
@@ -1,14 +1,14 @@
-import React, { PropsWithChildren, ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { useTableComponentsContext } from '../TableComponentsContext';
 
-interface HeaderCellOwnProps {
-  header: ReactNode;
-}
+interface HeaderCellOwnProps {}
 
 export type HeaderCellProps = PropsWithChildren<HeaderCellOwnProps>;
 
 export function HeaderCell(props: HeaderCellProps) {
+  const { children } = props;
+
   const Components = useTableComponentsContext();
 
-  return <Components.Th>{props.header}</Components.Th>;
+  return <Components.Th>{children}</Components.Th>;
 }


### PR DESCRIPTION
`HeaderCell` component used to receive `header` as prop and render it inside of `Components.Th`. For consistency we removed `header` prop, and now renders its `children` inside of `Components.Th`.