### PR TITLE
refactor(getvalue): rename value argument to data

### DIFF
--- a/src/utils/getValue.ts
+++ b/src/utils/getValue.ts
@@ -1,21 +1,21 @@
 import { Accessor } from './accessor';
 import { path } from './path';
 
-export function getValue<D, C>(value: D, accessor: null): null;
-export function getValue<D, C>(value: D, accessor: Accessor<D, C>): C;
+export function getValue<D, C>(data: D, accessor: null): null;
+export function getValue<D, C>(data: D, accessor: Accessor<D, C>): C;
 export function getValue<D, C>(
-  value: D,
+  data: D,
   accessor: Accessor<D, C> | null,
 ): C | null;
 export function getValue<D, C>(
-  value: D,
+  data: D,
   accessor: Accessor<D, C> | null,
 ): C | null {
   if (accessor === null) {
     return null;
   }
   if (typeof accessor === 'string') {
-    return path(accessor.split('.'), value) as C;
+    return path(accessor.split('.'), data) as C;
   }
-  return accessor(value);
+  return accessor(data);
 }


### PR DESCRIPTION
Rename `value` argument to a more meaningful name, `data`.