### PR TITLE
feat(columns): add part props in columns usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,6 @@ import { ComponentType } from 'react';
 import { Context } from 'react';
 import { ElementType } from 'react';
 import { PropsWithChildren } from 'react';
-import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 
 export declare type Accessor<D, C> = string | ((row: D) => C);
@@ -172,7 +171,7 @@ export declare const defaultTableComponents: TableComponents;
 
 export declare function findColumns<D extends object = {}>(
   children: ReactNode,
-): ReactElement | null;
+): ReactNode;
 
 export declare function getValue<D, C>(data: D, accessor: null): null;
 
@@ -339,13 +338,21 @@ export declare type TablePartProviderProps = PropsWithChildren<
   TablePartProviderOwnProps
 >;
 
-export declare type TablePartType = 'definition' | 'header' | 'body' | string;
+export declare type TablePartType = 'definition' | 'header' | 'body';
 
 export declare type TableProps<C extends ComponentType> = PropsWithChildren<
   TableOwnProps<C>
 >;
 
+export declare function UseColumns(props: UseColumnsProps): JSX.Element;
+
 export declare function useColumns(): ColumnsNode;
+
+declare interface UseColumnsOwnProps {
+  part?: string;
+}
+
+export declare type UseColumnsProps = PropsWithChildren<UseColumnsOwnProps>;
 
 export declare function useContent<V>(): Content<V>;
 

--- a/src/column/Column.tsx
+++ b/src/column/Column.tsx
@@ -4,8 +4,8 @@ import React, {
   PropsWithChildren,
   ReactNode,
 } from 'react';
-import { DefaultContent } from '..';
 import { Cell } from '../cell/Cell';
+import { DefaultContent } from '../content/DefaultContent';
 import { HeaderCell } from '../header/HeaderCell';
 import { useTablePart } from '../table/TablePartContext';
 import { Accessor } from '../utils/accessor';

--- a/src/column/Columns.tsx
+++ b/src/column/Columns.tsx
@@ -1,5 +1,6 @@
-import React, { Fragment, PropsWithChildren } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { useTablePart } from '../table/TablePartContext';
+import { UseColumns } from './UseColumns';
 
 interface ColumnsOwnProps {
   part?: string;
@@ -8,19 +9,12 @@ interface ColumnsOwnProps {
 export type ColumnsProps = PropsWithChildren<ColumnsOwnProps>;
 
 export function Columns(props: ColumnsProps) {
-  const { children, part } = props;
   const currentPart = useTablePart();
-  if (
-    part === undefined &&
-    currentPart !== 'header' &&
-    currentPart !== 'body'
-  ) {
+  const { part } = props;
+  if (currentPart === 'definition') {
     return null;
   }
-  if (part !== undefined && currentPart !== part) {
-    return null;
-  }
-  return <Fragment>{children}</Fragment>;
+  return <UseColumns part={part} />;
 }
 
 Columns.__COLUMNS__ = true;

--- a/src/column/UseColumns.tsx
+++ b/src/column/UseColumns.tsx
@@ -1,0 +1,22 @@
+import React, { Fragment, isValidElement, PropsWithChildren } from 'react';
+import { useColumns } from './ColumnsContext';
+
+interface UseColumnsOwnProps {
+  part?: string;
+}
+
+export type UseColumnsProps = PropsWithChildren<UseColumnsOwnProps>;
+
+export function UseColumns(props: UseColumnsProps) {
+  const columns = useColumns();
+
+  const partColumns = React.Children.map(columns, (child) => {
+    if (isValidElement(child)) {
+      if (child.props.part === props.part) {
+        return <Fragment>{child.props.children}</Fragment>;
+      }
+    }
+    return null;
+  });
+  return <Fragment>{partColumns}</Fragment>;
+}

--- a/src/column/findColumns.tsx
+++ b/src/column/findColumns.tsx
@@ -1,17 +1,19 @@
-import React, { ReactElement, ReactNode, Fragment } from 'react';
+import React, { ReactNode } from 'react';
 import { isColumnsType } from './ColumnsType';
 
 export function findColumns<D extends object = {}>(
   children: ReactNode,
-): ReactElement | null {
-  let columnsChildren = React.Children.map(children, (child) => {
-    if (
-      React.isValidElement<{ children?: ReactNode }>(child) &&
-      isColumnsType<D>(child.type)
-    ) {
-      return child;
-    }
-    return null;
-  });
-  return <Fragment>{columnsChildren}</Fragment>;
+): ReactNode {
+  return React.Children.map(
+    children,
+    (child): ReactNode => {
+      if (
+        React.isValidElement<{ children?: ReactNode }>(child) &&
+        isColumnsType<D>(child.type)
+      ) {
+        return child;
+      }
+      return null;
+    },
+  );
 }

--- a/src/header/HeaderRow.tsx
+++ b/src/header/HeaderRow.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, ComponentType, PropsWithChildren } from 'react';
-import { useColumns } from '../column/ColumnsContext';
+import { Columns } from '../column/Columns';
 import { useTableComponents } from '../TableComponentsContext';
 
 interface HeaderRowOwnProps<C extends ComponentType> {
@@ -13,10 +13,8 @@ export type HeaderRowProps<C extends ComponentType> = PropsWithChildren<
 export function HeaderRow<C extends ComponentType = ComponentType>(
   props: HeaderRowProps<C>,
 ) {
-  const { TrProps } = props;
+  const { TrProps, children = <Columns /> } = props;
   const Components = useTableComponents();
 
-  const columns = useColumns();
-
-  return <Components.Tr {...TrProps}>{columns}</Components.Tr>;
+  return <Components.Tr {...TrProps}>{children}</Components.Tr>;
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -4,7 +4,6 @@ import {
   ArrayOutput,
   Cell,
   Column,
-  Columns,
   ColumnsContext,
   ColumnsProvider,
   ContentContext,
@@ -35,6 +34,7 @@ import {
   TableHeader,
   TablePartContext,
   TablePartProvider,
+  Columns,
   useColumns,
   useContent,
   useContentValue,
@@ -44,6 +44,7 @@ import {
   useRowData,
   useTableComponents,
   useTablePart,
+  UseColumns,
 } from './index';
 
 const IndexCell = () => {
@@ -286,12 +287,14 @@ describe('ctablex', () => {
         </Columns>
         <Table>
           <TableHeader>
-            <HeaderRow />
+            <HeaderRow>
+              <Columns />
+            </HeaderRow>
           </TableHeader>
           <TableBody>
-            <TablePartProvider value="summary">
-              <Row row={summary} />
-            </TablePartProvider>
+            <Row row={summary}>
+              <Columns part="summary" />
+            </Row>
             <Rows>
               <Row />
             </Rows>
@@ -305,6 +308,15 @@ describe('ctablex', () => {
     // @ts-ignore
     console.error.mockImplementation(() => {});
     expect(() => render(<Row />)).toThrow();
+    expect(() => render(<Columns />)).toThrow();
+    expect(() => render(<UseColumns />)).toThrow();
+    expect(() =>
+      render(
+        <ColumnsProvider value={[null]}>
+          <UseColumns />
+        </ColumnsProvider>,
+      ),
+    ).not.toThrow();
     expect(() => render(<DefaultContent />)).toThrow();
     expect(() => render(<Column />)).toThrow();
     expect(() => render(<Cell accessor="id" />)).toThrow();
@@ -314,7 +326,9 @@ describe('ctablex', () => {
           <Columns />
           <Table>
             <TableBody>
-              <Row />
+              <Row>
+                <Columns />
+              </Row>
             </TableBody>
           </Table>
         </DataTable>,
@@ -340,6 +354,7 @@ describe('ctablex', () => {
     expect(DataContext).toBeDefined();
     expect(DataProvider).toBeDefined();
     expect(Columns).toBeDefined();
+    expect(UseColumns).toBeDefined();
     expect(Column).toBeDefined();
     expect(useColumns).toBeDefined();
     expect(ColumnsContext).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { useData, DataContext, DataProvider } from './data/DataContext';
 
 export { Columns } from './column/Columns';
+export { UseColumns } from './column/UseColumns';
 export { Column } from './column/Column';
 export {
   useColumns,

--- a/src/row/Row.tsx
+++ b/src/row/Row.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps, ComponentType, PropsWithChildren } from 'react';
 import { useCurrentValue } from '../array/CurrentValueContext';
-import { useColumns } from '../column/ColumnsContext';
+import { Columns } from '../column/Columns';
 import { useTableComponents } from '../TableComponentsContext';
 import { RowDataProvider } from './RowDataContext';
 
@@ -16,14 +16,13 @@ export type RowProps<D, C extends ComponentType> = PropsWithChildren<
 export function Row<D, C extends ComponentType = ComponentType>(
   props: RowProps<D, C>,
 ) {
-  const { TrProps } = props;
+  const { TrProps, children = <Columns /> } = props;
   const Components = useTableComponents();
 
-  const columns = useColumns();
   const row = useCurrentValue<D>(props.row);
   return (
     <RowDataProvider value={row}>
-      <Components.Tr {...TrProps}>{columns}</Components.Tr>
+      <Components.Tr {...TrProps}>{children}</Components.Tr>
     </RowDataProvider>
   );
 }

--- a/src/table/TablePartContext.tsx
+++ b/src/table/TablePartContext.tsx
@@ -5,7 +5,7 @@ import React, {
   useContext,
 } from 'react';
 
-export type TablePartType = 'definition' | 'header' | 'body' | string;
+export type TablePartType = 'definition' | 'header' | 'body';
 export type TablePart = TablePartType;
 export const TablePartContext: Context<TablePart | undefined> = createContext<
   TablePart | undefined

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,6 +23,7 @@ export { ArrayOutputProps } from './array/ArrayOutput';
 export { CellProps } from './cell/Cell';
 export { ColumnProps } from './column/Column';
 export { ColumnsProps } from './column/Columns';
+export { UseColumnsProps } from './column/UseColumns';
 export { ContentValueProps } from './content/ContentValue';
 export { DataTableProps } from './data/DataTable';
 export { DefaultContentProps } from './content/DefaultContent';


### PR DESCRIPTION
Introduce a new component: `UseColumns`. It will help to `HeaderRow` and `Row` be less magical.
 
```diff
- <HeaderRow />
+ <HeaderRow>
+   <UseColumns />
+ </HeaderRow>
```
```diff
- <Row />
+ <Row>
+   <UseColumns />
+ </Row>
```

I'm not happy with the `UseColumns` name. Please suggest some better names.


## suggestion 0:
- use `UseColumns` name
## suggestion 1:
- rename `Columns` to `ColumnsDefinition`
- use `Columns` name for `UseColumns` component

Cons. it will cause a breaking change

## suggestion 2:
- use `Columns` in both use case

Cons. Need some complex section
Pros. no need for breaking change

## suggestion 3:
- find better names

# TODO:
- [ ] ~keep old behavior for `Row` and `HeaderRow` and show a warning in development mode~

# Update:
suggestion 2 applied