### PR TITLE
feat: add default children to table/table-body/table-header/row/rows

### DIFF
--- a/src/header/TableHeader.tsx
+++ b/src/header/TableHeader.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps, ComponentType, PropsWithChildren } from 'react';
 import { TablePartProvider } from '../table/TablePartContext';
 import { useTableComponents } from '../TableComponentsContext';
+import { HeaderRow } from './HeaderRow';
 
 interface TableHeaderOwnProps<C extends ComponentType> {
   TheadProps?: Partial<ComponentProps<C>>;
@@ -13,7 +14,7 @@ export type TableHeaderProps<C extends ComponentType> = PropsWithChildren<
 export function TableHeader<C extends ComponentType = ComponentType>(
   props: TableHeaderProps<C>,
 ) {
-  const { children, TheadProps } = props;
+  const { children = <HeaderRow />, TheadProps } = props;
   const Components = useTableComponents();
 
   return (

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -89,16 +89,7 @@ describe('ctablex', () => {
           <Column header="Count" accessor="count" />
           <Column header="Color" accessor="color" />
         </Columns>
-        <Table>
-          <TableHeader>
-            <HeaderRow />
-          </TableHeader>
-          <TableBody>
-            <Rows>
-              <Row />
-            </Rows>
-          </TableBody>
-        </Table>
+        <Table />
       </DataTable>,
     );
   });

--- a/src/row/Rows.tsx
+++ b/src/row/Rows.tsx
@@ -3,6 +3,7 @@ import { ArrayOutput } from '../array/ArrayOutput';
 import { useData } from '../data/DataContext';
 import { Accessor } from '../utils/accessor';
 import { getValue } from '../utils/getValue';
+import { Row } from './Row';
 
 interface RowsOwnProps<D> {
   keyAccessor?: Accessor<D, string | number>;
@@ -12,7 +13,7 @@ interface RowsOwnProps<D> {
 export type RowsProps<D> = PropsWithChildren<RowsOwnProps<D>>;
 
 export function Rows<D>(props: RowsProps<D>) {
-  const { children, keyAccessor } = props;
+  const { children = <Row />, keyAccessor } = props;
   const data = useData<D>(props.data);
   const getKey = useMemo(() => {
     if (keyAccessor) {

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -1,5 +1,12 @@
-import React, { ComponentProps, ComponentType, PropsWithChildren } from 'react';
+import React, {
+  ComponentProps,
+  ComponentType,
+  PropsWithChildren,
+  Fragment,
+} from 'react';
+import { TableHeader } from '../header/TableHeader';
 import { useTableComponents } from '../TableComponentsContext';
+import { TableBody } from './TableBody';
 
 interface TableOwnProps<C extends ComponentType> {
   TableProps?: Partial<ComponentProps<C>>;
@@ -12,7 +19,13 @@ export type TableProps<C extends ComponentType> = PropsWithChildren<
 export function Table<C extends ComponentType = ComponentType>(
   props: TableProps<C>,
 ) {
-  const { children, TableProps } = props;
+  const defaultChildren = (
+    <Fragment>
+      <TableHeader />
+      <TableBody />
+    </Fragment>
+  );
+  const { children = defaultChildren, TableProps } = props;
   const Components = useTableComponents();
   return <Components.Table {...TableProps}>{children}</Components.Table>;
 }

--- a/src/table/TableBody.tsx
+++ b/src/table/TableBody.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentProps, ComponentType, PropsWithChildren } from 'react';
+import { Rows } from '../row/Rows';
 import { useTableComponents } from '../TableComponentsContext';
 import { TablePartProvider } from './TablePartContext';
 
@@ -13,7 +14,7 @@ export type TableBodyProps<D, C extends ComponentType> = PropsWithChildren<
 export function TableBody<D, C extends ComponentType = ComponentType>(
   props: TableBodyProps<D, C>,
 ) {
-  const { children, TbodyProps } = props;
+  const { children = <Rows />, TbodyProps } = props;
   const Components = useTableComponents();
 
   return (


### PR DESCRIPTION
with this PR, we can define tables with less code

## Old API
```tsx
    <DataTable data={data}>
      <Columns>
        <Column header="Name" accessor="name" />
        <Column header="Price" accessor="price" />
        <Column header="Count" accessor="count" />
      </Columns>
      <Table>
        <TableHeader>
          <HeaderRow />
        </TableHeader>
        <TableBody>
          <Rows>
            <Row />
          </Rows>
        </TableBody>
      </Table>
    </DataTable>
```
## New API
```tsx
    <DataTable data={data}>
      <Columns>
        <Column header="Name" accessor="name" />
        <Column header="Price" accessor="price" />
        <Column header="Count" accessor="count" />
      </Columns>
      <Table />
    </DataTable>
```
### More customization

```tsx
    <DataTable data={data}>
      <Columns>
        <Column header="Name" accessor="name" />
        <Column header="Price" accessor="price" />
        <Column header="Count" accessor="count" />
      </Columns>
      <Table>
        <TableHeader />
        <TableBody>
          <Row data={summary}/>
          <Rows />
        </TableBody>
      </Table>
    </DataTable>
```